### PR TITLE
Map to `clientExtensionResults` instead of `extensions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@passwordlessdev/passwordless-client",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/esm/passwordless.mjs",
   "types": "dist/passwordless.d.ts",
   "type": "module",

--- a/src/passwordless.ts
+++ b/src/passwordless.ts
@@ -175,7 +175,7 @@ export class Client {
                     id: credential.id,
                     rawId: arrayBufferToBase64Url(credential.rawId),
                     type: credential.type,
-                    extensions: credential.getClientExtensionResults(),
+                    clientExtensionResults: credential.getClientExtensionResults(),
                     response: {
                         AttestationObject: arrayBufferToBase64Url(
                             attestationResponse.attestationObject


### PR DESCRIPTION
We can publish this once we deploy with Fido.NET 4.0b9 or newer