### PR TITLE
Added stepup client method

### DIFF
--- a/src/passwordless.ts
+++ b/src/passwordless.ts
@@ -9,10 +9,10 @@ import {
 } from './types';
 
 export interface Config {
-  apiUrl: string;
-  apiKey: string;
-  origin: string;
-  rpid: string;
+    apiUrl: string;
+    apiKey: string;
+    origin: string;
+    rpid: string;
 }
 
 export class Client {
@@ -24,9 +24,9 @@ export class Client {
     };
     private abortController: AbortController = new AbortController();
 
-  constructor(config: AtLeast<Config, 'apiKey'>) {
-    Object.assign(this.config, config);
-  }
+    constructor(config: AtLeast<Config, 'apiKey'>) {
+        Object.assign(this.config, config);
+    }
 
     /**
      * Register a new credential to a user
@@ -44,25 +44,25 @@ export class Client {
                 return { error: registration.error }
             }
 
-      registration.data.challenge = base64UrlToArrayBuffer(registration.data.challenge);
-      registration.data.user.id = base64UrlToArrayBuffer(registration.data.user.id);
-      registration.data.excludeCredentials?.forEach((cred) => {
-        cred.id = base64UrlToArrayBuffer(cred.id);
-      });
+            registration.data.challenge = base64UrlToArrayBuffer(registration.data.challenge);
+            registration.data.user.id = base64UrlToArrayBuffer(registration.data.user.id);
+            registration.data.excludeCredentials?.forEach((cred) => {
+                cred.id = base64UrlToArrayBuffer(cred.id);
+            });
 
-      const credential = await navigator.credentials.create({
-        publicKey: registration.data,
-      }) as PublicKeyCredential;
+            const credential = await navigator.credentials.create({
+                publicKey: registration.data,
+            }) as PublicKeyCredential;
 
-      if (!credential) {
-        const error = {
-          from: "client",
-          errorCode: "failed_create_credential",
-          title: "Failed to create credential (navigator.credentials.create returned null)",
-        };
-        console.error(error);
-        return {error};
-      }
+            if (!credential) {
+                const error = {
+                    from: "client",
+                    errorCode: "failed_create_credential",
+                    title: "Failed to create credential (navigator.credentials.create returned null)",
+                };
+                console.error(error);
+                return {error};
+            }
 
             return await this.registerComplete(credential, registration.session, credentialNickname);
 
@@ -123,23 +123,23 @@ export class Client {
         return this.signin({ discoverable: true });
     }
 
-  public abort() {
-    if (this.abortController) {
-      this.abortController.abort();
+    public abort() {
+        if (this.abortController) {
+            this.abortController.abort();
+        }
     }
-  }
 
-  public isPlatformSupported(): Promise<boolean> {
-    return isPlatformSupported();
-  }
+    public isPlatformSupported(): Promise<boolean> {
+        return isPlatformSupported();
+    }
 
-  public isBrowserSupported(): boolean {
-    return isBrowserSupported();
-  }
+    public isBrowserSupported(): boolean {
+        return isBrowserSupported();
+    }
 
-  public isAutofillSupported(): Promise<boolean> {
-    return isAutofillSupported();
-  }
+    public isAutofillSupported(): Promise<boolean> {
+        return isAutofillSupported();
+    }
 
     private async registerBegin(token: string): PromiseResult<RegisterBeginResponse> {
         const response = await fetch(`${this.config.apiUrl}/register/begin`, {
@@ -152,20 +152,20 @@ export class Client {
             }),
         });
 
-    const res = await response.json();
-    if (response.ok) {
-      return res;
-    }
+        const res = await response.json();
+        if (response.ok) {
+            return res;
+        }
 
         return { error: { ...res, from: "server" } };
     }
 
-  private async registerComplete(
-    credential: PublicKeyCredential,
-    session: string,
-    credentialNickname: string,
-  ): PromiseResult<TokenResponse> {
-    const attestationResponse = credential.response as AuthenticatorAttestationResponse;
+    private async registerComplete(
+        credential: PublicKeyCredential,
+        session: string,
+        credentialNickname: string,
+    ): PromiseResult<TokenResponse> {
+        const attestationResponse = credential.response as AuthenticatorAttestationResponse;
 
         const response = await fetch(`${this.config.apiUrl}/register/complete`, {
             method: 'POST',
@@ -192,10 +192,10 @@ export class Client {
             }),
         });
 
-    const res = await response.json();
-    if (response.ok) {
-      return res;
-    }
+        const res = await response.json();
+        if (response.ok) {
+            return res;
+        }
 
         return { error: { ...res, from: "server" } };
     }
@@ -222,11 +222,11 @@ export class Client {
                 return signin;
             }
 
-      const credential = await navigator.credentials.get({
-        publicKey: signin.data,
-        mediation: 'autofill' in signinMethod ? "conditional" as CredentialMediationRequirement : undefined, // Typescript doesn't know about 'conditational' yet
-        signal: this.abortController.signal,
-      }) as PublicKeyCredential;
+            const credential = await navigator.credentials.get({
+                publicKey: signin.data,
+                mediation: 'autofill' in signinMethod ? "conditional" as CredentialMediationRequirement : undefined, // Typescript doesn't know about 'conditational' yet
+                signal: this.abortController.signal,
+            }) as PublicKeyCredential;
 
             const response = await this.signinComplete(credential, signin.session);
             return response;
@@ -241,95 +241,95 @@ export class Client {
             console.error(caughtError);
             console.error(error);
 
-      return {error};
-    }
-  }
-
-  /**
-   * Performs a step-up authentication process. This is essentially an overload for the sign-in workflow. It allows for
-   * a user authentication to be given a purpose or context for the sign-in, enabling a "step-up" authentication flow.
-   *
-   * @param {StepupRequest} stepup - The step-up request object. This includes the sign-in method and the purpose of the authentication
-   * @param {function} callback - The optional callback function to handle the result of the step-up process.
-   *                             Receives the token as the first argument and optional additional arguments.
-   * @returns {object} - The result of the step-up process. If a callback function is provided, it returns
-   *                    the result of the callback function; otherwise, it returns the result directly.
-   */
-  public async stepup(stepup: StepupRequest, callback?: (token: string | undefined, args?: any) => any) {
-    try {
-      this.assertBrowserSupported();
-      this.handleAbort();
-
-      if (!stepup.signinMethod) {
-        throw new Error("You need to provide the signInMethod");
-      }
-
-      const signin = await this.signinBegin(stepup.signinMethod, stepup.purpose);
-
-      if (signin.error) {
-        return signin;
-      }
-
-      const credential = await navigator.credentials.get({
-        publicKey: signin.data,
-        mediation: 'autofill' in stepup.signinMethod ? "conditional" as CredentialMediationRequirement : undefined, // Typescript doesn't know about 'conditional' yet
-        signal: this.abortController.signal,
-      }) as PublicKeyCredential;
-
-      const signInComplete = await this.signinComplete(credential, signin.session);
-
-      return callback === undefined || callback === null
-        ? signInComplete
-        : callback(signInComplete.token);
-    } catch (caughtError: any) {
-      const errorMessage = getErrorMessage(caughtError);
-      const error = {
-        from: "client",
-        errorCode: "unknown",
-        title: errorMessage,
-      };
-      console.error(caughtError);
-      console.error(error);
-
-      return {error};
-    }
-  }
-
-  private async signinBegin(signinMethod: SigninMethod, purpose?: string): PromiseResult<SigninBeginResponse> {
-    const response = await fetch(`${this.config.apiUrl}/signin/begin`, {
-      method: 'POST',
-      headers: this.createHeaders(),
-      body: JSON.stringify({
-        userId: "userId" in signinMethod ? signinMethod.userId : undefined,
-        alias: "alias" in signinMethod ? signinMethod.alias : undefined,
-        RPID: this.config.rpid,
-        Origin: this.config.origin,
-        purpose: purpose
-      }),
-    });
-
-    const res = await response.json();
-    if (response.ok) {
-      return {
-        ...res,
-        data: {
-          ...res.data,
-          challenge: base64UrlToArrayBuffer(res.data.challenge),
-          allowCredentials: res.data.allowCredentials?.map((cred: PublicKeyCredentialDescriptor) => {
-            return {...cred, id: base64UrlToArrayBuffer(cred.id)};
-          })
+            return {error};
         }
-      };
     }
+
+    /**
+     * Performs a step-up authentication process. This is essentially an overload for the sign-in workflow. It allows for
+     * a user authentication to be given a purpose or context for the sign-in, enabling a "step-up" authentication flow.
+     *
+     * @param {StepupRequest} stepup - The step-up request object. This includes the sign-in method and the purpose of the authentication
+     * @param {function} callback - The optional callback function to handle the result of the step-up process.
+     *                             Receives the token as the first argument and optional additional arguments.
+     * @returns {object} - The result of the step-up process. If a callback function is provided, it returns
+     *                    the result of the callback function; otherwise, it returns the result directly.
+     */
+    public async stepup(stepup: StepupRequest, callback?: (token: string | undefined, args?: any) => any) {
+        try {
+            this.assertBrowserSupported();
+            this.handleAbort();
+
+            if (!stepup.signinMethod) {
+                throw new Error("You need to provide the signInMethod");
+            }
+
+            const signin = await this.signinBegin(stepup.signinMethod, stepup.purpose);
+
+            if (signin.error) {
+                return signin;
+            }
+
+            const credential = await navigator.credentials.get({
+                publicKey: signin.data,
+                mediation: 'autofill' in stepup.signinMethod ? "conditional" as CredentialMediationRequirement : undefined, // Typescript doesn't know about 'conditional' yet
+                signal: this.abortController.signal,
+            }) as PublicKeyCredential;
+
+            const signInComplete = await this.signinComplete(credential, signin.session);
+
+            return callback === undefined || callback === null
+                ? signInComplete
+                : callback(signInComplete.token);
+        } catch (caughtError: any) {
+            const errorMessage = getErrorMessage(caughtError);
+            const error = {
+                from: "client",
+                errorCode: "unknown",
+                title: errorMessage,
+            };
+            console.error(caughtError);
+            console.error(error);
+
+            return {error};
+        }
+    }
+
+    private async signinBegin(signinMethod: SigninMethod, purpose?: string): PromiseResult<SigninBeginResponse> {
+        const response = await fetch(`${this.config.apiUrl}/signin/begin`, {
+            method: 'POST',
+            headers: this.createHeaders(),
+            body: JSON.stringify({
+                userId: "userId" in signinMethod ? signinMethod.userId : undefined,
+                alias: "alias" in signinMethod ? signinMethod.alias : undefined,
+                RPID: this.config.rpid,
+                Origin: this.config.origin,
+                purpose: purpose
+            }),
+        });
+
+        const res = await response.json();
+        if (response.ok) {
+            return {
+                ...res,
+                data: {
+                    ...res.data,
+                    challenge: base64UrlToArrayBuffer(res.data.challenge),
+                    allowCredentials: res.data.allowCredentials?.map((cred: PublicKeyCredentialDescriptor) => {
+                        return {...cred, id: base64UrlToArrayBuffer(cred.id)};
+                    })
+                }
+            };
+        }
 
         return { error: { ...res, from: "server" } };
     }
 
-  private async signinComplete(
-    credential: PublicKeyCredential,
-    session: string,
-  ): PromiseResult<TokenResponse> {
-    const assertionResponse = credential.response as AuthenticatorAssertionResponse;
+    private async signinComplete(
+        credential: PublicKeyCredential,
+        session: string,
+    ): PromiseResult<TokenResponse> {
+        const assertionResponse = credential.response as AuthenticatorAssertionResponse;
 
         const response = await fetch(`${this.config.apiUrl}/signin/complete`, {
             method: 'POST',
@@ -358,123 +358,123 @@ export class Client {
             }),
         });
 
-    const res = await response.json();
-    if (response.ok) {
-      return res;
-    }
+        const res = await response.json();
+        if (response.ok) {
+            return res;
+        }
 
         return { error: { ...res, from: "server" } };
     }
 
-  private handleAbort() {
-    this.abort();
-    this.abortController = new AbortController();
-  }
-
-  private assertBrowserSupported(): void {
-    if (!isBrowserSupported()) {
-      throw new Error('WebAuthn and PublicKeyCredentials are not supported on this browser/device');
+    private handleAbort() {
+        this.abort();
+        this.abortController = new AbortController();
     }
-  }
 
-  private createHeaders(): Record<string, string> {
-    return {
-      ApiKey: this.config.apiKey,
-      'Content-Type': 'application/json',
-      'Client-Version': 'js-1.1.0'
-    };
-  }
+    private assertBrowserSupported(): void {
+        if (!isBrowserSupported()) {
+            throw new Error('WebAuthn and PublicKeyCredentials are not supported on this browser/device');
+        }
+    }
+
+    private createHeaders(): Record<string, string> {
+        return {
+            ApiKey: this.config.apiKey,
+            'Content-Type': 'application/json',
+            'Client-Version': 'js-1.1.0'
+        };
+    }
 }
 
 export async function isPlatformSupported(): Promise<boolean> {
-  if (!isBrowserSupported()) return false;
-  return PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
+    if (!isBrowserSupported()) return false;
+    return PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
 }
 
 export function isBrowserSupported(): boolean {
-  return window.PublicKeyCredential !== undefined && typeof window.PublicKeyCredential === 'function';
+    return window.PublicKeyCredential !== undefined && typeof window.PublicKeyCredential === 'function';
 }
 
 export async function isAutofillSupported(): Promise<boolean> {
-  const PublicKeyCredential = window.PublicKeyCredential as any; // Typescript lacks support for this
-  if (!PublicKeyCredential.isConditionalMediationAvailable) return false;
-  return PublicKeyCredential.isConditionalMediationAvailable() as Promise<boolean>;
+    const PublicKeyCredential = window.PublicKeyCredential as any; // Typescript lacks support for this
+    if (!PublicKeyCredential.isConditionalMediationAvailable) return false;
+    return PublicKeyCredential.isConditionalMediationAvailable() as Promise<boolean>;
 }
 
 function base64ToBase64Url(base64: string): string {
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=*$/g, '');
+    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=*$/g, '');
 }
 
 function base64UrlToBase64(base64Url: string): string {
-  return base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    return base64Url.replace(/-/g, '+').replace(/_/g, '/');
 }
 
 function base64UrlToArrayBuffer(base64UrlString: string | BufferSource): ArrayBuffer {
-  // improvement: Remove BufferSource-type and add proper types upstream
-  if (typeof base64UrlString !== 'string') {
-    const msg = "Cannot convert from Base64Url to ArrayBuffer: Input was not of type string";
-    console.error(msg, base64UrlString);
-    throw new TypeError(msg);
-  }
+    // improvement: Remove BufferSource-type and add proper types upstream
+    if (typeof base64UrlString !== 'string') {
+        const msg = "Cannot convert from Base64Url to ArrayBuffer: Input was not of type string";
+        console.error(msg, base64UrlString);
+        throw new TypeError(msg);
+    }
 
-  const base64Unpadded = base64UrlToBase64(base64UrlString);
-  const paddingNeeded = (4 - (base64Unpadded.length % 4)) % 4;
-  const base64Padded = base64Unpadded.padEnd(base64Unpadded.length + paddingNeeded, "=");
+    const base64Unpadded = base64UrlToBase64(base64UrlString);
+    const paddingNeeded = (4 - (base64Unpadded.length % 4)) % 4;
+    const base64Padded = base64Unpadded.padEnd(base64Unpadded.length + paddingNeeded, "=");
 
-  const binary = window.atob(base64Padded);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
+    const binary = window.atob(base64Padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
 
-  return bytes;
+    return bytes;
 }
 
 function arrayBufferToBase64Url(buffer: ArrayBuffer | Uint8Array): string {
-  const uint8Array = (() => {
-    if (Array.isArray(buffer)) return Uint8Array.from(buffer);
-    if (buffer instanceof ArrayBuffer) return new Uint8Array(buffer);
-    if (buffer instanceof Uint8Array) return buffer;
+    const uint8Array = (() => {
+        if (Array.isArray(buffer)) return Uint8Array.from(buffer);
+        if (buffer instanceof ArrayBuffer) return new Uint8Array(buffer);
+        if (buffer instanceof Uint8Array) return buffer;
 
-    const msg = "Cannot convert from ArrayBuffer to Base64Url. Input was not of type ArrayBuffer, Uint8Array or Array";
-    console.error(msg, buffer);
-    throw new Error(msg);
-  })();
+        const msg = "Cannot convert from ArrayBuffer to Base64Url. Input was not of type ArrayBuffer, Uint8Array or Array";
+        console.error(msg, buffer);
+        throw new Error(msg);
+    })();
 
-  let string = '';
-  for (let i = 0; i < uint8Array.byteLength; i++) {
-    string += String.fromCharCode(uint8Array[i]);
-  }
+    let string = '';
+    for (let i = 0; i < uint8Array.byteLength; i++) {
+        string += String.fromCharCode(uint8Array[i]);
+    }
 
-  const base64String = window.btoa(string);
-  return base64ToBase64Url(base64String);
+    const base64String = window.btoa(string);
+    return base64ToBase64Url(base64String);
 }
 
 type ErrorWithMessage = {
-  message: string
+    message: string
 }
 
 function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'message' in error &&
-    typeof (error as Record<string, unknown>).message === 'string'
-  )
+    return (
+        typeof error === 'object' &&
+        error !== null &&
+        'message' in error &&
+        typeof (error as Record<string, unknown>).message === 'string'
+    )
 }
 
 function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
-  if (isErrorWithMessage(maybeError)) return maybeError
+    if (isErrorWithMessage(maybeError)) return maybeError
 
-  try {
-    return new Error(JSON.stringify(maybeError))
-  } catch {
-    // fallback in case there's an error stringifying the maybeError
-    // like with circular references for example.
-    return new Error(String(maybeError))
-  }
+    try {
+        return new Error(JSON.stringify(maybeError))
+    } catch {
+        // fallback in case there's an error stringifying the maybeError
+        // like with circular references for example.
+        return new Error(String(maybeError))
+    }
 }
 
 function getErrorMessage(error: unknown) {
-  return toErrorWithMessage(error).message
+    return toErrorWithMessage(error).message
 }

--- a/src/passwordless.ts
+++ b/src/passwordless.ts
@@ -259,7 +259,7 @@ export class Client {
             this.handleAbort();
 
             if (!stepup.signinMethod) {
-                throw new Error("You need to provide the signInMethod");
+                throw new Error("You need to provide the signinMethod");
             }
 
             if (!stepup.purpose) {

--- a/src/passwordless.ts
+++ b/src/passwordless.ts
@@ -61,7 +61,7 @@ export class Client {
                     title: "Failed to create credential (navigator.credentials.create returned null)",
                 };
                 console.error(error);
-                return {error};
+                return { error };
             }
 
             return await this.registerComplete(credential, registration.session, credentialNickname);
@@ -241,7 +241,7 @@ export class Client {
             console.error(caughtError);
             console.error(error);
 
-            return {error};
+            return { error };
         }
     }
 
@@ -291,7 +291,7 @@ export class Client {
             console.error(caughtError);
             console.error(error);
 
-            return {error};
+            return { error };
         }
     }
 
@@ -316,7 +316,7 @@ export class Client {
                     ...res.data,
                     challenge: base64UrlToArrayBuffer(res.data.challenge),
                     allowCredentials: res.data.allowCredentials?.map((cred: PublicKeyCredentialDescriptor) => {
-                        return {...cred, id: base64UrlToArrayBuffer(cred.id)};
+                        return { ...cred, id: base64UrlToArrayBuffer(cred.id) };
                     })
                 }
             };

--- a/src/passwordless.ts
+++ b/src/passwordless.ts
@@ -250,12 +250,10 @@ export class Client {
      * a user authentication to be given a purpose or context for the sign-in, enabling a "step-up" authentication flow.
      *
      * @param {StepupRequest} stepup - The step-up request object. This includes the sign-in method and the purpose of the authentication
-     * @param {function} callback - The optional callback function to handle the result of the step-up process.
-     *                             Receives the token as the first argument and optional additional arguments.
-     * @returns {object} - The result of the step-up process. If a callback function is provided, it returns
-     *                    the result of the callback function; otherwise, it returns the result directly.
+     *
+     * @returns {token} - The result of the step-up sign-in process.
      */
-    public async stepup(stepup: StepupRequest, callback?: (token: string | undefined, args?: any) => any) {
+    public async stepup(stepup: StepupRequest) {
         try {
             this.assertBrowserSupported();
             this.handleAbort();
@@ -280,11 +278,7 @@ export class Client {
                 signal: this.abortController.signal,
             }) as PublicKeyCredential;
 
-            const signInComplete = await this.signinComplete(credential, signin.session);
-
-            return callback === undefined || callback === null
-                ? signInComplete
-                : callback(signInComplete.token);
+            return await this.signinComplete(credential, signin.session);
         } catch (caughtError: any) {
             const errorMessage = getErrorMessage(caughtError);
             const error = {

--- a/src/passwordless.ts
+++ b/src/passwordless.ts
@@ -264,6 +264,10 @@ export class Client {
                 throw new Error("You need to provide the signInMethod");
             }
 
+            if (!stepup.purpose) {
+                stepup.purpose = "step-up";
+            }
+
             const signin = await this.signinBegin(stepup.signinMethod, stepup.purpose);
 
             if (signin.error) {

--- a/src/passwordless.ts
+++ b/src/passwordless.ts
@@ -253,7 +253,7 @@ export class Client {
      *
      * @returns {token} - The result of the step-up sign-in process.
      */
-    public async stepup(stepup: StepupRequest) {
+    public async stepup(stepup: StepupRequest) : PromiseResult<TokenResponse> {
         try {
             this.assertBrowserSupported();
             this.handleAbort();

--- a/src/passwordless.ts
+++ b/src/passwordless.ts
@@ -245,7 +245,17 @@ export class Client {
     }
   }
 
-  public async stepup(stepup: StepupRequest, callback: (token: string | undefined, args?: any) => any) {
+  /**
+   * Performs a step-up authentication process. This is essentially an overload for the sign-in workflow. It allows for
+   * a user authentication to be given a purpose or context for the sign-in, enabling a "step-up" authentication flow.
+   *
+   * @param {object} stepup - The step-up request object. This includes the sign-in method and the purpose of the authentication
+   * @param {function} callback - The optional callback function to handle the result of the step-up process.
+   *                             Receives the token as the first argument and optional additional arguments.
+   * @returns {object} - The result of the step-up process. If a callback function is provided, it returns
+   *                    the result of the callback function; otherwise, it returns the result directly.
+   */
+  public async stepup(stepup: StepupRequest, callback?: (token: string | undefined, args?: any) => any) {
     try {
       this.assertBrowserSupported();
       this.handleAbort();

--- a/src/passwordless.ts
+++ b/src/passwordless.ts
@@ -249,7 +249,7 @@ export class Client {
    * Performs a step-up authentication process. This is essentially an overload for the sign-in workflow. It allows for
    * a user authentication to be given a purpose or context for the sign-in, enabling a "step-up" authentication flow.
    *
-   * @param {object} stepup - The step-up request object. This includes the sign-in method and the purpose of the authentication
+   * @param {StepupRequest} stepup - The step-up request object. This includes the sign-in method and the purpose of the authentication
    * @param {function} callback - The optional callback function to handle the result of the step-up process.
    *                             Receives the token as the first argument and optional additional arguments.
    * @returns {object} - The result of the step-up process. If a callback function is provided, it returns

--- a/src/passwordless.ts
+++ b/src/passwordless.ts
@@ -221,11 +221,6 @@ export class Client {
                 return signin;
             }
 
-      signin.data.challenge = base64UrlToArrayBuffer(signin.data.challenge);
-      signin.data.allowCredentials?.forEach((cred) => {
-        cred.id = base64UrlToArrayBuffer(cred.id);
-      });
-
       const credential = await navigator.credentials.get({
         publicKey: signin.data,
         mediation: 'autofill' in signinMethod ? "conditional" as CredentialMediationRequirement : undefined, // Typescript doesn't know about 'conditational' yet
@@ -263,7 +258,15 @@ export class Client {
 
     const res = await response.json();
     if (response.ok) {
-      return res;
+      return {
+        ...res,
+        data: {
+          ...res.data,
+          allowCredentials: res.data.allowCredentials?.map((cred: PublicKeyCredentialDescriptor) => {
+            return {...cred, id: base64UrlToArrayBuffer(cred.id)};
+          })
+        }
+      };
     }
 
         return { error: { ...res, from: "server" } };

--- a/src/passwordless.ts
+++ b/src/passwordless.ts
@@ -8,10 +8,10 @@ import {
 } from './types';
 
 export interface Config {
-    apiUrl: string;
-    apiKey: string;
-    origin: string;
-    rpid: string;
+  apiUrl: string;
+  apiKey: string;
+  origin: string;
+  rpid: string;
 }
 
 export class Client {
@@ -19,13 +19,13 @@ export class Client {
         apiUrl: 'https://v4.passwordless.dev',
         apiKey: '',
         origin: window.location.origin,
-        rpid: window.location.hostname
+        rpid: window.location.hostname,
     };
     private abortController: AbortController = new AbortController();
 
-    constructor(config: AtLeast<Config, 'apiKey'>) {
-        Object.assign(this.config, config);
-    }
+  constructor(config: AtLeast<Config, 'apiKey'>) {
+    Object.assign(this.config, config);
+  }
 
     /**
      * Register a new credential to a user
@@ -43,25 +43,25 @@ export class Client {
                 return { error: registration.error }
             }
 
-            registration.data.challenge = base64UrlToArrayBuffer(registration.data.challenge);
-            registration.data.user.id = base64UrlToArrayBuffer(registration.data.user.id);
-            registration.data.excludeCredentials?.forEach((cred) => {
-                cred.id = base64UrlToArrayBuffer(cred.id);
-            });
+      registration.data.challenge = base64UrlToArrayBuffer(registration.data.challenge);
+      registration.data.user.id = base64UrlToArrayBuffer(registration.data.user.id);
+      registration.data.excludeCredentials?.forEach((cred) => {
+        cred.id = base64UrlToArrayBuffer(cred.id);
+      });
 
-            const credential = await navigator.credentials.create({
-                publicKey: registration.data,
-            }) as PublicKeyCredential;
+      const credential = await navigator.credentials.create({
+        publicKey: registration.data,
+      }) as PublicKeyCredential;
 
-            if (!credential) {
-                const error = {
-                    from: "client",
-                    errorCode: "failed_create_credential",
-                    title: "Failed to create credential (navigator.credentials.create returned null)",
-                };
-                console.error(error);
-                return { error };
-            }
+      if (!credential) {
+        const error = {
+          from: "client",
+          errorCode: "failed_create_credential",
+          title: "Failed to create credential (navigator.credentials.create returned null)",
+        };
+        console.error(error);
+        return {error};
+      }
 
             return await this.registerComplete(credential, registration.session, credentialNickname);
 
@@ -122,23 +122,23 @@ export class Client {
         return this.signin({ discoverable: true });
     }
 
-    public abort() {
-        if (this.abortController) {
-            this.abortController.abort();
-        }
+  public abort() {
+    if (this.abortController) {
+      this.abortController.abort();
     }
+  }
 
-    public isPlatformSupported(): Promise<boolean> {
-        return isPlatformSupported();
-    }
+  public isPlatformSupported(): Promise<boolean> {
+    return isPlatformSupported();
+  }
 
-    public isBrowserSupported(): boolean {
-        return isBrowserSupported();
-    }
+  public isBrowserSupported(): boolean {
+    return isBrowserSupported();
+  }
 
-    public isAutofillSupported(): Promise<boolean> {
-        return isAutofillSupported();
-    }
+  public isAutofillSupported(): Promise<boolean> {
+    return isAutofillSupported();
+  }
 
     private async registerBegin(token: string): PromiseResult<RegisterBeginResponse> {
         const response = await fetch(`${this.config.apiUrl}/register/begin`, {
@@ -147,24 +147,24 @@ export class Client {
             body: JSON.stringify({
                 token,
                 RPID: this.config.rpid,
-                Origin: this.config.origin
+                Origin: this.config.origin,
             }),
         });
 
-        const res = await response.json();
-        if (response.ok) {
-            return res;
-        }
+    const res = await response.json();
+    if (response.ok) {
+      return res;
+    }
 
         return { error: { ...res, from: "server" } };
     }
 
-    private async registerComplete(
-        credential: PublicKeyCredential,
-        session: string,
-        credentialNickname: string,
-    ): PromiseResult<TokenResponse> {
-        const attestationResponse = credential.response as AuthenticatorAttestationResponse;
+  private async registerComplete(
+    credential: PublicKeyCredential,
+    session: string,
+    credentialNickname: string,
+  ): PromiseResult<TokenResponse> {
+    const attestationResponse = credential.response as AuthenticatorAttestationResponse;
 
         const response = await fetch(`${this.config.apiUrl}/register/complete`, {
             method: 'POST',
@@ -191,10 +191,10 @@ export class Client {
             }),
         });
 
-        const res = await response.json();
-        if (response.ok) {
-            return res;
-        }
+    const res = await response.json();
+    if (response.ok) {
+      return res;
+    }
 
         return { error: { ...res, from: "server" } };
     }
@@ -221,16 +221,16 @@ export class Client {
                 return signin;
             }
 
-            signin.data.challenge = base64UrlToArrayBuffer(signin.data.challenge);
-            signin.data.allowCredentials?.forEach((cred) => {
-                cred.id = base64UrlToArrayBuffer(cred.id);
-            });
+      signin.data.challenge = base64UrlToArrayBuffer(signin.data.challenge);
+      signin.data.allowCredentials?.forEach((cred) => {
+        cred.id = base64UrlToArrayBuffer(cred.id);
+      });
 
-            const credential = await navigator.credentials.get({
-                publicKey: signin.data,
-                mediation: 'autofill' in signinMethod ? "conditional" as CredentialMediationRequirement : undefined, // Typescript doesn't know about 'conditational' yet
-                signal: this.abortController.signal,
-            }) as PublicKeyCredential;
+      const credential = await navigator.credentials.get({
+        publicKey: signin.data,
+        mediation: 'autofill' in signinMethod ? "conditional" as CredentialMediationRequirement : undefined, // Typescript doesn't know about 'conditational' yet
+        signal: this.abortController.signal,
+      }) as PublicKeyCredential;
 
             const response = await this.signinComplete(credential, signin.session);
             return response;
@@ -245,35 +245,35 @@ export class Client {
             console.error(caughtError);
             console.error(error);
 
-            return { error };
-        }
+      return {error};
     }
+  }
 
-    private async signinBegin(signinMethod: SigninMethod): PromiseResult<SigninBeginResponse> {
-        const response = await fetch(`${this.config.apiUrl}/signin/begin`, {
-            method: 'POST',
-            headers: this.createHeaders(),
-            body: JSON.stringify({
-                userId: "userId" in signinMethod ? signinMethod.userId : undefined,
-                alias: "alias" in signinMethod ? signinMethod.alias : undefined,
-                RPID: this.config.rpid,
-                Origin: this.config.origin,
-            }),
-        });
+  private async signinBegin(signinMethod: SigninMethod): PromiseResult<SigninBeginResponse> {
+    const response = await fetch(`${this.config.apiUrl}/signin/begin`, {
+      method: 'POST',
+      headers: this.createHeaders(),
+      body: JSON.stringify({
+        userId: "userId" in signinMethod ? signinMethod.userId : undefined,
+        alias: "alias" in signinMethod ? signinMethod.alias : undefined,
+        RPID: this.config.rpid,
+        Origin: this.config.origin,
+      }),
+    });
 
-        const res = await response.json();
-        if (response.ok) {
-            return res;
-        }
+    const res = await response.json();
+    if (response.ok) {
+      return res;
+    }
 
         return { error: { ...res, from: "server" } };
     }
 
-    private async signinComplete(
-        credential: PublicKeyCredential,
-        session: string,
-    ): PromiseResult<TokenResponse> {
-        const assertionResponse = credential.response as AuthenticatorAssertionResponse;
+  private async signinComplete(
+    credential: PublicKeyCredential,
+    session: string,
+  ): PromiseResult<TokenResponse> {
+    const assertionResponse = credential.response as AuthenticatorAssertionResponse;
 
         const response = await fetch(`${this.config.apiUrl}/signin/complete`, {
             method: 'POST',
@@ -302,123 +302,123 @@ export class Client {
             }),
         });
 
-        const res = await response.json();
-        if (response.ok) {
-            return res;
-        }
+    const res = await response.json();
+    if (response.ok) {
+      return res;
+    }
 
         return { error: { ...res, from: "server" } };
     }
 
-    private handleAbort() {
-        this.abort();
-        this.abortController = new AbortController();
-    }
+  private handleAbort() {
+    this.abort();
+    this.abortController = new AbortController();
+  }
 
-    private assertBrowserSupported(): void {
-        if (!isBrowserSupported()) {
-            throw new Error('WebAuthn and PublicKeyCredentials are not supported on this browser/device');
-        }
+  private assertBrowserSupported(): void {
+    if (!isBrowserSupported()) {
+      throw new Error('WebAuthn and PublicKeyCredentials are not supported on this browser/device');
     }
+  }
 
-    private createHeaders(): Record<string, string> {
-        return {
-            ApiKey: this.config.apiKey,
-            'Content-Type': 'application/json',
-            'Client-Version': 'js-1.1.0'
-        };
-    }
+  private createHeaders(): Record<string, string> {
+    return {
+      ApiKey: this.config.apiKey,
+      'Content-Type': 'application/json',
+      'Client-Version': 'js-1.1.0'
+    };
+  }
 }
 
 export async function isPlatformSupported(): Promise<boolean> {
-    if (!isBrowserSupported()) return false;
-    return PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
+  if (!isBrowserSupported()) return false;
+  return PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
 }
 
 export function isBrowserSupported(): boolean {
-    return window.PublicKeyCredential !== undefined && typeof window.PublicKeyCredential === 'function';
+  return window.PublicKeyCredential !== undefined && typeof window.PublicKeyCredential === 'function';
 }
 
 export async function isAutofillSupported(): Promise<boolean> {
-    const PublicKeyCredential = window.PublicKeyCredential as any; // Typescript lacks support for this
-    if (!PublicKeyCredential.isConditionalMediationAvailable) return false;
-    return PublicKeyCredential.isConditionalMediationAvailable() as Promise<boolean>;
+  const PublicKeyCredential = window.PublicKeyCredential as any; // Typescript lacks support for this
+  if (!PublicKeyCredential.isConditionalMediationAvailable) return false;
+  return PublicKeyCredential.isConditionalMediationAvailable() as Promise<boolean>;
 }
 
 function base64ToBase64Url(base64: string): string {
-    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=*$/g, '');
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=*$/g, '');
 }
 
 function base64UrlToBase64(base64Url: string): string {
-    return base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  return base64Url.replace(/-/g, '+').replace(/_/g, '/');
 }
 
 function base64UrlToArrayBuffer(base64UrlString: string | BufferSource): ArrayBuffer {
-    // improvement: Remove BufferSource-type and add proper types upstream
-    if (typeof base64UrlString !== 'string') {
-        const msg = "Cannot convert from Base64Url to ArrayBuffer: Input was not of type string";
-        console.error(msg, base64UrlString);
-        throw new TypeError(msg);
-    }
+  // improvement: Remove BufferSource-type and add proper types upstream
+  if (typeof base64UrlString !== 'string') {
+    const msg = "Cannot convert from Base64Url to ArrayBuffer: Input was not of type string";
+    console.error(msg, base64UrlString);
+    throw new TypeError(msg);
+  }
 
-    const base64Unpadded = base64UrlToBase64(base64UrlString);
-    const paddingNeeded = (4 - (base64Unpadded.length % 4)) % 4;
-    const base64Padded = base64Unpadded.padEnd(base64Unpadded.length + paddingNeeded, "=");
+  const base64Unpadded = base64UrlToBase64(base64UrlString);
+  const paddingNeeded = (4 - (base64Unpadded.length % 4)) % 4;
+  const base64Padded = base64Unpadded.padEnd(base64Unpadded.length + paddingNeeded, "=");
 
-    const binary = window.atob(base64Padded);
-    const bytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) {
-        bytes[i] = binary.charCodeAt(i);
-    }
+  const binary = window.atob(base64Padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
 
-    return bytes;
+  return bytes;
 }
 
 function arrayBufferToBase64Url(buffer: ArrayBuffer | Uint8Array): string {
-    const uint8Array = (() => {
-        if (Array.isArray(buffer)) return Uint8Array.from(buffer);
-        if (buffer instanceof ArrayBuffer) return new Uint8Array(buffer);
-        if (buffer instanceof Uint8Array) return buffer;
+  const uint8Array = (() => {
+    if (Array.isArray(buffer)) return Uint8Array.from(buffer);
+    if (buffer instanceof ArrayBuffer) return new Uint8Array(buffer);
+    if (buffer instanceof Uint8Array) return buffer;
 
-        const msg = "Cannot convert from ArrayBuffer to Base64Url. Input was not of type ArrayBuffer, Uint8Array or Array";
-        console.error(msg, buffer);
-        throw new Error(msg);
-    })();
+    const msg = "Cannot convert from ArrayBuffer to Base64Url. Input was not of type ArrayBuffer, Uint8Array or Array";
+    console.error(msg, buffer);
+    throw new Error(msg);
+  })();
 
-    let string = '';
-    for (let i = 0; i < uint8Array.byteLength; i++) {
-        string += String.fromCharCode(uint8Array[i]);
-    }
+  let string = '';
+  for (let i = 0; i < uint8Array.byteLength; i++) {
+    string += String.fromCharCode(uint8Array[i]);
+  }
 
-    const base64String = window.btoa(string);
-    return base64ToBase64Url(base64String);
+  const base64String = window.btoa(string);
+  return base64ToBase64Url(base64String);
 }
 
 type ErrorWithMessage = {
-    message: string
+  message: string
 }
 
 function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
-    return (
-        typeof error === 'object' &&
-        error !== null &&
-        'message' in error &&
-        typeof (error as Record<string, unknown>).message === 'string'
-    )
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof (error as Record<string, unknown>).message === 'string'
+  )
 }
 
 function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
-    if (isErrorWithMessage(maybeError)) return maybeError
+  if (isErrorWithMessage(maybeError)) return maybeError
 
-    try {
-        return new Error(JSON.stringify(maybeError))
-    } catch {
-        // fallback in case there's an error stringifying the maybeError
-        // like with circular references for example.
-        return new Error(String(maybeError))
-    }
+  try {
+    return new Error(JSON.stringify(maybeError))
+  } catch {
+    // fallback in case there's an error stringifying the maybeError
+    // like with circular references for example.
+    return new Error(String(maybeError))
+  }
 }
 
 function getErrorMessage(error: unknown) {
-    return toErrorWithMessage(error).message
+  return toErrorWithMessage(error).message
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,34 @@
 export type AtLeast<T, K extends keyof T> = Partial<T> & Pick<T, K>;
 
+/**
+ * Represents a sign-in method.
+ */
 export type SigninMethod = { userId: string } | { alias: string } | { autofill: boolean } | { discoverable: boolean };
+
+/**
+ *
+ */
+export interface StepupRequest {
+    signinMethod: SigninMethod;
+    context: StepupContext;
+}
+
+/**
+ * Represents the context for step-up authentication.
+ * @interface
+ */
+export interface StepupContext {
+    /**
+     *
+     */
+    context: string;
+    /**
+     * Time to Live (TTL) in seconds.
+     *
+     * @type {number}
+     */
+    ttl: number;
+}
 
 export type RegisterBeginResponse = {
     session: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,24 +10,7 @@ export type SigninMethod = { userId: string } | { alias: string } | { autofill: 
  */
 export interface StepupRequest {
     signinMethod: SigninMethod;
-    context: StepupContext;
-}
-
-/**
- * Represents the context for step-up authentication.
- * @interface
- */
-export interface StepupContext {
-    /**
-     *
-     */
-    context: string;
-    /**
-     * Time to Live (TTL) in seconds.
-     *
-     * @type {number}
-     */
-    ttl: number;
+    purpose: string;
 }
 
 export type RegisterBeginResponse = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,9 @@ export type AtLeast<T, K extends keyof T> = Partial<T> & Pick<T, K>;
 export type SigninMethod = { userId: string } | { alias: string } | { autofill: boolean } | { discoverable: boolean };
 
 /**
+ * Represents a step-up request to initiate a specific action or operation.
  *
+ * @interface StepupRequest
  */
 export interface StepupRequest {
     signinMethod: SigninMethod;


### PR DESCRIPTION
### Ticket
- Closes [PAS-299](https://bitwarden.atlassian.net/browse/PAS-299)

### Description
This adds the `stepup` client method for authenticating a user for a specific purpose or action.

### Shape
`Stepup` is an overload for the `signin` method with the addition of the purpose to `signinBegin`.

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- Tested the generated js file in the Passwordless dotnet sdk repo and used that instead of the cdn.

I did the following to ensure that my changes do not introduce security vulnerabilities:
N/A


[PAS-299]: https://bitwarden.atlassian.net/browse/PAS-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ