### PR TITLE
Set version to zeroes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@passwordlessdev/passwordless-client",
-  "version": "1.3.0",
+  "version": "0.0.0",
   "main": "dist/esm/passwordless.mjs",
   "types": "dist/passwordless.d.ts",
   "type": "module",


### PR DESCRIPTION
To avoid accidentally deploying the wrong version. The actual version is inferred from the git tag now.