### PR TITLE
[PAS-596] Adding getTransports to register

### DIFF
--- a/src/passwordless.ts
+++ b/src/passwordless.ts
@@ -183,7 +183,8 @@ export class Client {
           clientExtensionResults: credential.getClientExtensionResults(),
           response: {
             AttestationObject: arrayBufferToBase64Url(attestationResponse.attestationObject),
-            clientDataJson: arrayBufferToBase64Url(attestationResponse.clientDataJSON)
+            clientDataJson: arrayBufferToBase64Url(attestationResponse.clientDataJSON),
+            transports: attestationResponse.getTransports ? attestationResponse.getTransports() : [] // we might need to provide a default here if the browser doesn't support the call.
           }
         },
         nickname: credentialNickname,


### PR DESCRIPTION
### Ticket
- Closes [PAS-596](https://bitwarden.atlassian.net/browse/PAS-596)

### Description
This adds `getTransports()` from the attestation response to the `register/complete` request. It is now required from the Fido2 lib object.
### Checklist

I did the following to ensure that my changes were tested thoroughly:

- \_\_

I did the following to ensure that my changes do not introduce security vulnerabilities:

- \_\_


[PAS-596]: https://bitwarden.atlassian.net/browse/PAS-596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ